### PR TITLE
Enable using ng-repeat in the hotColumn directive

### DIFF
--- a/src/directives/ngHandsontable.js
+++ b/src/directives/ngHandsontable.js
@@ -149,7 +149,9 @@ angular.module('ngHandsontable.directives', [])
                   column['data'] = attributes[i];
                 }
                 else {
-                  column[i] = scope.$eval(attributes[i]);
+                  if (i !== 'ngRepeat') {
+                    column[i] = scope.$eval(attributes[i]);
+                  }
                 }
               }
             }


### PR DESCRIPTION
This commit fixes an error occuring when trying to use hotColumn with ngRepeat by ignoring the ngRepeat attribute.
